### PR TITLE
improve dryRun for continuous integration

### DIFF
--- a/tasks/lib/phpcsfixer.js
+++ b/tasks/lib/phpcsfixer.js
@@ -126,8 +126,6 @@ exports.init = function(grunt) {
                 grunt.log.ok("PHP files fixed!");
             }
 
-            
-            grunt.log.ok("PHP files fixed!");
             done();
         });
     };


### PR DESCRIPTION
When dry run is enabled it should trigger error for continuous integration for example.
I also added different success message for dry run. 
