### PR TITLE
dry-run/verbose/ignoreExitCode interaction

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,9 +13,8 @@ module.exports = function(grunt) {
       },
       options: {
         bin: "vendor/bin/php-cs-fixer",
-        ignoreExitCode: false,
         level: "all",
-        quiet: true
+        verbose: true
       }
     }
   });


### PR DESCRIPTION
`ignoreExitCode` is useless when used with `dryRun`, it will stop execution when fixes are found no matter ignoreExitCode!

changes to dry-run/verbose/ignoreExitCode interaction:
- only with `verbose` will php-cs-fixer messages be printed out
- `dryRun` doesn't stop execution when fixes found IF `ignoreExitCode` is set to true

Additionally `.php_cs` configfile is normally used to set paths to files/directories to be checked and fixes configurations, so in that case it is not _absolutely_ necessary to set `dir` on the task
