### PR TITLE
Adjust config for php-cs-fixer 2.0

### DIFF
--- a/tasks/lib/phpcsfixer.js
+++ b/tasks/lib/phpcsfixer.js
@@ -58,10 +58,10 @@ exports.init = function(grunt) {
             appends.push("--diff");
         }
 
-        if (grunt.option("allowRisky") || config.diff) {
+        if (grunt.option("allowRisky") || config.allowRisky) {
             appends.push("--allow-risky yes");
         }
-        
+
         if (grunt.option("configfile") || config.configfile) {
             appends.push("--config=" + config.configfile);
         }
@@ -134,7 +134,12 @@ exports.init = function(grunt) {
                         return;
                     }
 
-                    if (err && config.dryRun) {
+                    if (err && err.code != 0 && !config.ignoreExitCode) {
+                        callback(err, null);
+                        return;
+                    }
+
+                    if (err && err.code == 0 && config.dryRun) {
                         callback(err, null);
                         return;
                     }

--- a/tasks/lib/phpcsfixer.js
+++ b/tasks/lib/phpcsfixer.js
@@ -18,10 +18,10 @@ exports.init = function(grunt) {
         defaults = {
             // Default options
             bin: "php-cs-fixer",
-            level: null,
-            fixers: null,
+            rules: null,
             dryRun: false,
             diff: false,
+            allowRisky: false,
             verbose: false,
             quiet: false,
             ignoreExitCode: false,
@@ -45,13 +45,9 @@ exports.init = function(grunt) {
             appends.push("--verbose");
         }
 
-        if (grunt.option("level") || config.level) {
-            appends.push("--level=" + config.level);
-        }
-
-        if (grunt.option("fixers") || config.fixers) {
-            var fixers = _.isString(config.fixers) ? config.fixers.split(",") : config.fixers;
-            appends.push("--fixers=" + fixers.join(","));
+        if (grunt.option("rules") || config.rules) {
+            var rules = _.isString(config.rules) ? config.rules.split(",") : config.rules;
+            appends.push("--rules=" + rules.join(","));
         }
 
         if (grunt.option("dryRun") || config.dryRun) {
@@ -62,12 +58,12 @@ exports.init = function(grunt) {
             appends.push("--diff");
         }
 
-        if (grunt.option("framework") || config.framework) {
-            appends.push("--config=" + config.framework);
+        if (grunt.option("allowRisky") || config.diff) {
+            appends.push("--allow-risky yes");
         }
         
         if (grunt.option("configfile") || config.configfile) {
-            appends.push("--config-file=" + config.configfile);
+            appends.push("--config=" + config.configfile);
         }
 
         var bin = path.normalize(config.bin),
@@ -109,7 +105,7 @@ exports.init = function(grunt) {
     };
 
     /**
-     * Runs phpunit command with options
+     * Runs php-cs-fixer command with options
      *
      */
     exports.run = function() {


### PR DESCRIPTION
Removes --levels and --fixers, adds --rules and --allow-risky.

If this looks good to you, I'll also update the documentation.