### PR TITLE
Added cacheFile grunt option to append --cache-file php-cs-fixer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ Type: `Boolean` Default: `no`
 
 _Controls whether a local cache is used, accepted values are "yes" or "no"._
 
+#### cacheFile
+Type: `String` Default: `null`
+
+_Specifies the cache file name and location._
+
 #### rules
 Type: `String` Default: `(all PSR rules)`
 

--- a/tasks/lib/phpcsfixer.js
+++ b/tasks/lib/phpcsfixer.js
@@ -19,6 +19,7 @@ exports.init = function(grunt) {
             // Default options
             bin: "php-cs-fixer",
             usingCache: false,
+            cacheFile: false,
             rules: null,
             dryRun: false,
             diff: false,
@@ -68,6 +69,10 @@ exports.init = function(grunt) {
 
         if (grunt.option("usingCache") || config.usingCache) {
             appends.push("--using-cache " + config.usingCache);
+        }
+
+        if (grunt.option("cacheFile") || config.cacheFile) {
+            appends.push("--cache-file " + config.cacheFile);
         }
 
         if (grunt.option("configfile") || config.configfile) {


### PR DESCRIPTION
Fixes #12 

Adds a cacheFile option and documentation to append the --cache-file php-cs-fixer option which can be used to specify the location and file name for the cache file. PHP-CS-Fixer documentation [here](https://github.com/FriendsOfPHP/PHP-CS-Fixer#caching).